### PR TITLE
Fix: Require tilt, if Tilt module is defined

### DIFF
--- a/lib/rack/server_pages.rb
+++ b/lib/rack/server_pages.rb
@@ -228,6 +228,8 @@ module Rack
       end
 
       class TiltTemplate < Template
+        require 'tilt'
+
         def find_template
           @tilt ||= Tilt[@file]
           @tilt ? self : nil


### PR DESCRIPTION
This Fixes #14.

### Testing.
1. Start a project that has both `slack-ruby-client` and `sidekiq-scheduler` as dependencies in the GemFile
2. Start puma `bundle exec puma -p 4000`
3. Browse to `localhost:4000` and verify that you do not receive an error caused by Tilt module missing methods.

### Notes

There might be a cleaner way to detect whether Tilt has been loaded in the `tilt?` method on `lib/rack/server_pages.rb:193`, which would not necessitate using Tilt, unless the user has explicitly required it. My ruby wizardry is shamefully lacking, and I do not know how to do this; I'm open to suggestions.